### PR TITLE
changed TarsosDSPExamples/pom.xml to depend on TarsosDSP 1.5

### DIFF
--- a/TarsosDSPExamples/pom.xml
+++ b/TarsosDSPExamples/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>be.hogent.tarsos.dsp.example</groupId>
   <artifactId>TarsosDSPExamples</artifactId>
-  <version>1.4</version>
+  <version>1.5</version>
   <packaging>jar</packaging>
 
   <name>TarsosDSPExamples</name>
@@ -348,7 +348,7 @@
     <dependency>
 	  <groupId>be.hogent.tarsos.dsp</groupId>
 	  <artifactId>TarsosDSP</artifactId>
-	  <version>1.4</version>
+	  <version>1.5</version>
 	  <type>jar</type>
 	  <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
mvn install didn't work (windows xp) since the dependency was wrong. Now it depends on TarsosDSP 1.5.
