### PR TITLE
Fixed bug in AudioEvent.java

### DIFF
--- a/TarsosDSP/src/main/java/be/hogent/tarsos/dsp/AudioEvent.java
+++ b/TarsosDSP/src/main/java/be/hogent/tarsos/dsp/AudioEvent.java
@@ -166,7 +166,7 @@ public class AudioEvent {
 	public static double calculateRMS(float[] floatBuffer){
 		double rms = 0.0;
 		for (int i = 0; i < floatBuffer.length; i++) {
-			rms =+ floatBuffer[i] * floatBuffer[i];
+			rms += floatBuffer[i] * floatBuffer[i];
 		}
 		rms = rms / Double.valueOf(floatBuffer.length);
 		rms = Math.sqrt(rms);


### PR DESCRIPTION
Fixed bug in AudioEvent.java. In function calculateRMS line 169 should be rms += instead of rms =+
This was affecting BeatRootSpectralFluxOnsetDetector.java which uses audioEvent.getRMS()
