### PR TITLE
infinite loop fix (when stopped becomes true)

### DIFF
--- a/src/be/tarsos/dsp/AudioDispatcher.java
+++ b/src/be/tarsos/dsp/AudioDispatcher.java
@@ -424,7 +424,7 @@ public class AudioDispatcher implements Runnable {
 		}else{
 			int currentBytesRead = 0;
 			//Always read a full byte buffer!
-			while(bytesRead != -1 && currentBytesRead<byteStepSize){
+			while(bytesRead != -1 && currentBytesRead<byteStepSize && !stopped){
 				bytesRead = audioInputStream.read(audioByteBuffer, byteOverlap + currentBytesRead , byteStepSize - currentBytesRead);
 				currentBytesRead += bytesRead;
 			}


### PR DESCRIPTION
Even after we check if "stopped" true or false, it can become true from another thread when we are in "while" loop, what, in my case, caused infinite loop and heavy cpu load later. We need to check it every time in while loop condition.