### PR TITLE
AudioDispatcherFactory should throw exception

### DIFF
--- a/src/android/be/tarsos/dsp/io/android/AudioDispatcherFactory.java
+++ b/src/android/be/tarsos/dsp/io/android/AudioDispatcherFactory.java
@@ -71,8 +71,7 @@ public class AudioDispatcherFactory {
 		audioInputStream.startRecording();
 		return new AudioDispatcher(audioStream,audioBufferSize,bufferOverlap);
 		}else{
-			new IllegalArgumentException("Buffer size too small should be at least " + (minAudioBufferSize *2));
-			return null;
+			throw new IllegalArgumentException("Buffer size too small should be at least " + (minAudioBufferSize *2));
 		}
 		
 		


### PR DESCRIPTION
In my opinion this should be right behavior.
Before we don't know why AudioDispatcher is null. For example I tested library on old 2.3 Android device and spend many time to find cause of my problem. Logs did not explain anything.