### PR TITLE
Fix spelling mistake in McLeodPitchMethod class.

### DIFF
--- a/src/core/be/tarsos/dsp/pitch/McLeodPitchMethod.java
+++ b/src/core/be/tarsos/dsp/pitch/McLeodPitchMethod.java
@@ -223,7 +223,7 @@ public final class McLeodPitchMethod implements PitchDetector {
 
 			if (nsdf[tau] > SMALL_CUTOFF) {
 				// calculates turningPointX and Y
-				prabolicInterpolation(tau);
+				parabolicInterpolation(tau);
 				// store the turning points
 				ampEstimates.add(turningPointY);
 				periodEstimates.add(turningPointX);
@@ -300,7 +300,7 @@ public final class McLeodPitchMethod implements PitchDetector {
 	 * @param tau
 	 *            The delay tau, b value in the drawing is the tau value.
 	 */
-	private void prabolicInterpolation(final int tau) {
+	private void parabolicInterpolation(final int tau) {
 		final float nsdfa = nsdf[tau - 1];
 		final float nsdfb = nsdf[tau];
 		final float nsdfc = nsdf[tau + 1];


### PR DESCRIPTION
There was a spelling mistake in which parabolic was spelled "prabolic." I fixed it here.