### PR TITLE
Fix FFMPEGDownloader to download using HTTPS

### DIFF
--- a/src/core/be/tarsos/dsp/util/FFMPEGDownloader.java
+++ b/src/core/be/tarsos/dsp/util/FFMPEGDownloader.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
  */
 public class FFMPEGDownloader {
 	
-	private static String url = "http://0110.be/releases/TarsosDSP/TarsosDSP-static-ffmpeg/";
+	private static String url = "https://0110.be/releases/TarsosDSP/TarsosDSP-static-ffmpeg/";
 	
 	private final String ffmpegBinary;
 	


### PR DESCRIPTION
0110.be only allows file downloads over https.

Another idea might to also just include the binaries in the jar file, reducing download time and allows the program to function even if 0110.be goes down (not sure who currently maintains the site or for how long it is expected to stay up). Also moving the binaries to another github repository for download that way would be a possible solution.