### PR TITLE
zero fill audioFloatBuffer in generateNextAudioBlock

### DIFF
--- a/src/core/be/tarsos/dsp/AudioGenerator.java
+++ b/src/core/be/tarsos/dsp/AudioGenerator.java
@@ -245,6 +245,9 @@ public class AudioGenerator implements Runnable {
 		if(audioFloatBuffer.length == floatOverlap + floatStepSize ){
 			System.arraycopy(audioFloatBuffer, floatStepSize, audioFloatBuffer,0 ,floatOverlap);
 		}
+		// Zero-fill rest of the buffer
+		for(int i=floatOverlap; i < audioFloatBuffer.length; i++)
+			audioFloatBuffer[i] = 0;
 		samplesProcessed += floatStepSize;
 	}
 	


### PR DESCRIPTION
After shifting data in audioFloatBuffer make sure to zerofill to the end,
getting ready for next audio generation pass.

The SineGenerator adds the wave to data already in the audioFloatBuffer, 
so it is important that the used portion of the buffer be zeroed before 
each pass through the audio processor list.