### PR TITLE
Remove unused constants from Mpm, Yin, FastYin

### DIFF
--- a/src/core/be/tarsos/dsp/pitch/FastYin.java
+++ b/src/core/be/tarsos/dsp/pitch/FastYin.java
@@ -59,16 +59,6 @@ public final class FastYin implements PitchDetector {
 	private static final double DEFAULT_THRESHOLD = 0.20;
 
 	/**
-	 * The default size of an audio buffer (in samples).
-	 */
-	public static final int DEFAULT_BUFFER_SIZE = 2048;
-
-	/**
-	 * The default overlap of two consecutive audio buffers (in samples).
-	 */
-	public static final int DEFAULT_OVERLAP = 1536;
-
-	/**
 	 * The actual YIN threshold.
 	 */
 	private final double threshold;

--- a/src/core/be/tarsos/dsp/pitch/McLeodPitchMethod.java
+++ b/src/core/be/tarsos/dsp/pitch/McLeodPitchMethod.java
@@ -71,12 +71,6 @@ public final class McLeodPitchMethod implements PitchDetector {
 	public static final int DEFAULT_BUFFER_SIZE = 1024;
 
 	/**
-	 * Overlap defines how much two audio buffers following each other should
-	 * overlap (in samples). 75% overlap is advised in the MPM article.
-	 */
-	public static final int DEFAULT_OVERLAP = 768;
-
-	/**
 	 * Defines the relative size the chosen peak (pitch) has. 0.93 means: choose
 	 * the first peak that is higher than 93% of the highest peak detected. 93%
 	 * is the default value used in the Tartini user interface.

--- a/src/core/be/tarsos/dsp/pitch/Yin.java
+++ b/src/core/be/tarsos/dsp/pitch/Yin.java
@@ -41,16 +41,6 @@ public final class Yin implements PitchDetector {
 	private static final double DEFAULT_THRESHOLD = 0.20;
 
 	/**
-	 * The default size of an audio buffer (in samples).
-	 */
-	public static final int DEFAULT_BUFFER_SIZE = 2048;
-
-	/**
-	 * The default overlap of two consecutive audio buffers (in samples).
-	 */
-	public static final int DEFAULT_OVERLAP = 1536;
-
-	/**
 	 * The actual YIN threshold.
 	 */
 	private final double threshold;


### PR DESCRIPTION
I don't think these are used - feels like they're left over from somewhere. I built the examples and ran the Pitch Detector example without issues from this branch.