### PR TITLE
Bug fix: calculateFilterBanks for loop overwrites centerFrequencies[0] set earlier in the method

### DIFF
--- a/src/core/be/tarsos/dsp/mfcc/MFCC.java
+++ b/src/core/be/tarsos/dsp/mfcc/MFCC.java
@@ -127,7 +127,7 @@ public class MFCC implements AudioProcessor {
         //Calculates te centerfrequencies.
         for (int i = 1; i <= amountOfMelFilters; i++) {
             float fc = (inverseMel(mel[0] + factor * i) / sampleRate) * samplesPerFrame;
-            centerFrequencies[i - 1] = Math.round(fc);
+            centerFrequencies[i] = Math.round(fc);
         }
 
     }


### PR DESCRIPTION
Removed the `-1` from the `centerFrequencies` index: `i` starts with `1` so without this change the loop will overwrite the value set in the earlier line: `centerFrequencies[0] = Math.round(lowerFilterFreq / sampleRate * samplesPerFrame);`