### PR TITLE
soundPressureLevel(): fix bug in computation of sound pressure

### DIFF
--- a/src/core/be/tarsos/dsp/AudioEvent.java
+++ b/src/core/be/tarsos/dsp/AudioEvent.java
@@ -203,25 +203,9 @@ public class AudioEvent {
 	 *            The buffer with audio information.
 	 * @return The dBSPL level for the buffer.
 	 */
-	private double soundPressureLevel(final float[] buffer) {
-		double value = Math.pow(localEnergy(buffer), 0.5);
-		value = value / buffer.length;
-		return linearToDecibel(value);
-	}
-	
-	/**
-	 * Calculates the local (linear) energy of an audio buffer.
-	 * 
-	 * @param buffer
-	 *            The audio buffer.
-	 * @return The local (linear) energy of an audio buffer.
-	 */
-	private double localEnergy(final float[] buffer) {
-		double power = 0.0D;
-		for (float element : buffer) {
-			power += element * element;
-		}
-		return power;
+	private static double soundPressureLevel(final float[] buffer) {
+		double rms = calculateRMS(buffer);
+		return linearToDecibel(rms);
 	}
 	
 	/**
@@ -231,7 +215,7 @@ public class AudioEvent {
 	 *            The value to convert.
 	 * @return The converted value.
 	 */
-	private double linearToDecibel(final double value) {
+	private static double linearToDecibel(final double value) {
 		return 20.0 * Math.log10(value);
 	}
 

--- a/src/core/be/tarsos/dsp/SilenceDetector.java
+++ b/src/core/be/tarsos/dsp/SilenceDetector.java
@@ -57,18 +57,21 @@ public class SilenceDetector implements AudioProcessor {
 	}
 
 	/**
-	 * Calculates the local (linear) energy of an audio buffer.
-	 * 
-	 * @param buffer
-	 *            The audio buffer.
-	 * @return The local (linear) energy of an audio buffer.
+	 * Calculates and returns the root mean square of the signal. Please
+	 * cache the result since it is calculated every time.
+	 * @param floatBuffer The audio buffer to calculate the RMS for.
+	 * @return The <a
+	 *         href="http://en.wikipedia.org/wiki/Root_mean_square">RMS</a> of
+	 *         the signal present in the current buffer.
 	 */
-	private double localEnergy(final float[] buffer) {
-		double power = 0.0D;
-		for (float element : buffer) {
-			power += element * element;
+	public static double calculateRMS(float[] floatBuffer){
+		double rms = 0.0;
+		for (int i = 0; i < floatBuffer.length; i++) {
+			rms += floatBuffer[i] * floatBuffer[i];
 		}
-		return power;
+		rms = rms / Double.valueOf(floatBuffer.length);
+		rms = Math.sqrt(rms);
+		return rms;
 	}
 
 	/**
@@ -78,10 +81,9 @@ public class SilenceDetector implements AudioProcessor {
 	 *            The buffer with audio information.
 	 * @return The dBSPL level for the buffer.
 	 */
-	private double soundPressureLevel(final float[] buffer) {
-		double value = Math.pow(localEnergy(buffer), 0.5);
-		value = value / buffer.length;
-		return linearToDecibel(value);
+	private static double soundPressureLevel(final float[] buffer) {
+		double rms = calculateRMS(buffer);
+		return linearToDecibel(rms);
 	}
 
 	/**
@@ -91,7 +93,7 @@ public class SilenceDetector implements AudioProcessor {
 	 *            The value to convert.
 	 * @return The converted value.
 	 */
-	private double linearToDecibel(final double value) {
+	private static double linearToDecibel(final double value) {
 		return 20.0 * Math.log10(value);
 	}
 	

--- a/src/experimental/be/tarsos/dsp/experimental/AudioEvent.java
+++ b/src/experimental/be/tarsos/dsp/experimental/AudioEvent.java
@@ -142,25 +142,9 @@ public class AudioEvent {
 	 *            The buffer with audio information.
 	 * @return The dBSPL level for the buffer.
 	 */
-	private double soundPressureLevel(final float[] buffer) {
-		double value = Math.pow(localEnergy(buffer), 0.5);
-		value = value / buffer.length;
-		return linearToDecibel(value);
-	}
-	
-	/**
-	 * Calculates the local (linear) energy of an audio buffer.
-	 * 
-	 * @param buffer
-	 *            The audio buffer.
-	 * @return The local (linear) energy of an audio buffer.
-	 */
-	private double localEnergy(final float[] buffer) {
-		double power = 0.0D;
-		for (float element : buffer) {
-			power += element * element;
-		}
-		return power;
+	private static double soundPressureLevel(final float[] buffer) {
+		double rms = calculateRMS(buffer);
+		return linearToDecibel(rms);
 	}
 	
 	/**
@@ -170,7 +154,7 @@ public class AudioEvent {
 	 *            The value to convert.
 	 * @return The converted value.
 	 */
-	private double linearToDecibel(final double value) {
+	private static double linearToDecibel(final double value) {
 		return 20.0 * Math.log10(value);
 	}
 }


### PR DESCRIPTION
The [previous implementation](https://github.com/JorenSix/TarsosDSP/blob/master/src/core/be/tarsos/dsp/AudioEvent.java#L207) first took square root of the energy,
then divided that by number of samples to get "average", whereas
the correct procedure is first to take the average of the energy
(to get "average square") and then take the square root.

Thus, the previous implementation divided the RMS by additional
`sqrt(buffer.length)` term, causing the sound pressure to go 
to zero with increasing buffer size (and also, not actually computing
sound pressure).

For instance:
```
buffer = [2, -2, 2, -2, 2, ...] of len N
energy = N * 4
rms = sqrt(energy / N) = 2

# now, correctly
sound_pressure_correct = linearToDecibel(2)

# previously, wrong (e.g. L207 @ AudioEvent)
value = sqrt(energy) = 2 * sqrt(N)
avg = value / N = 2 / sqrt(N)
sound_pressure = linearToDecibel(avg) = linearToDecibel(2 / sqrt(N))
```

Apart from that, the PR adds a few `static` keywords & removes (now unused) `localEnergy` function.