### PR TITLE
Allow injection of PitchDetector into PitchProcessor.

### DIFF
--- a/core/src/main/java/be/tarsos/dsp/pitch/PitchProcessor.java
+++ b/core/src/main/java/be/tarsos/dsp/pitch/PitchProcessor.java
@@ -124,6 +124,20 @@ public class PitchProcessor implements AudioProcessor {
 		detector = algorithm.getDetector(sampleRate, bufferSize);
 		this.handler = handler;	
 	}
+
+	/**
+	 * Initialize a new pitch processor.
+	 * 
+	 * @param detector 
+	 * 			The pitch detector to use.
+	 * 
+	 * @param handler
+	 * 			The handler handles detected pitch.
+	 */
+	public PitchProcessor(PitchDetector detector, PitchDetectionHandler handler) {
+		this.detector = detector;
+		this.handler = handler;
+	}
 	
 	@Override
 	public boolean process(AudioEvent audioEvent) {


### PR DESCRIPTION
Added constructor with `PitchDetector` parameter to `PitchProcessor`, allowing the internal pitch detector used to be specified:

```java
public PitchProcessor(PitchDetector detector, PitchDetectionHandler handler)
```

This allows the specific parameters of each pitch estimation algorithm to be specified when using the pitch processor.

For example the min and max frequency for AMDF:

```java
PitchProcessor pitchProcessor = new PitchProcessor(
    AMDF(
        sampleRate,
        audioBufferSize,
        minFrequency,
        maxFrequency
    ),
    pitchDetectionHandler
)
```

The existing constructor is maintained to still allow ease of use by specifying the relevant enum to use the default parameters.